### PR TITLE
implement KeysetPageSource and MenuKeysetPages

### DIFF
--- a/discord/ext/menus/__init__.py
+++ b/discord/ext/menus/__init__.py
@@ -945,8 +945,6 @@ class KeysetPageSource:
 
         Subclasses must implement this.
 
-        .. note::
-
         Parameters
         -----------
         specifier: :class:`PageSpecifier`
@@ -957,6 +955,11 @@ class KeysetPageSource:
         Any
             The object represented by that page.
             This is passed into :meth:`format_page`.
+
+        Raises
+        -------
+        ValueError
+            The requested page is out of range.
         """
         raise NotImplementedError
 
@@ -1197,6 +1200,13 @@ class MenuKeysetPages(Menu):
         await self._source._prepare_once()
         await super().start(ctx, channel=channel, wait=wait)
 
+    async def show_checked_page(self, specifier):
+        try:
+            await self.show_page(specifier)
+        except ValueError:
+            # An error happened that can be handled, so ignore it.
+            pass
+
     async def show_current_page(self):
         if self._source.paginating:
             await self.show_page(self.current_page)
@@ -1205,25 +1215,25 @@ class MenuKeysetPages(Menu):
             position=First(0))
     async def go_to_first_page(self, payload):
         """go to the first page"""
-        await self.show_page(PageSpecifier.first())
+        await self.show_checked_page(PageSpecifier.first())
 
     @button('\N{BLACK LEFT-POINTING TRIANGLE}\ufe0f', position=First(1))
     async def go_to_previous_page(self, payload):
         """go to the previous page"""
         self.current_page.direction = PageDirection.before
-        await self.show_page(self.current_page)
+        await self.show_checked_page(self.current_page)
 
     @button('\N{BLACK RIGHT-POINTING TRIANGLE}\ufe0f', position=Last(0))
     async def go_to_next_page(self, payload):
         """go to the next page"""
         self.current_page.direction = PageDirection.after
-        await self.show_page(self.current_page)
+        await self.show_checked_page(self.current_page)
 
     @button('\N{BLACK RIGHT-POINTING DOUBLE TRIANGLE WITH VERTICAL BAR}\ufe0f',
             position=Last(1))
     async def go_to_last_page(self, payload):
         """go to the last page"""
-        await self.show_page(PageSpecifier.last())
+        await self.show_checked_page(PageSpecifier.last())
 
     @button('\N{BLACK SQUARE FOR STOP}\ufe0f', position=Last(2))
     async def stop_pages(self, payload):

--- a/discord/ext/menus/__init__.py
+++ b/discord/ext/menus/__init__.py
@@ -325,7 +325,7 @@ class Menu(metaclass=_MenuMeta):
         self.clear_reactions_after = clear_reactions_after
         self.check_embeds = check_embeds
         self._can_remove_reactions = False
-        self.__task = None
+        self.__tasks = []
         self._running = True
         self.message = message
         self.ctx = None
@@ -439,7 +439,7 @@ class Menu(metaclass=_MenuMeta):
         self._buttons.pop(emoji, None)
 
         if react:
-            if self.__task is not None:
+            if self.__tasks:
                 async def wrapped():
                     # Remove the reaction from being processable
                     # Removing it from the cache first makes it so the check
@@ -479,7 +479,7 @@ class Menu(metaclass=_MenuMeta):
         self._buttons.clear()
 
         if react:
-            if self.__task is not None:
+            if self.__tasks:
                 async def wrapped():
                     # A fast path if we have permissions
                     if self._can_remove_reactions:
@@ -687,14 +687,18 @@ class Menu(metaclass=_MenuMeta):
 
         if self.should_add_reactions():
             # Start the task first so we can listen to reactions before doing anything
-            if self.__task is not None:
-                self.__task.cancel()
+            if self.__tasks:
+                for task in self.__tasks:
+                    task.cancel()
+                self.__tasks.clear()
 
             self._running = True
-            self.__task = bot.loop.create_task(self._internal_loop())
+            self.__tasks.append(bot.loop.create_task(self._internal_loop()))
 
-            for emoji in self.buttons:
-                await msg.add_reaction(emoji)
+            async def add_reactions_task():
+                for emoji in self.buttons:
+                    await msg.add_reaction(emoji)
+            self.__tasks.append(bot.loop.create_task(add_reactions_task()))
 
             if wait:
                 await self._event.wait()
@@ -736,9 +740,10 @@ class Menu(metaclass=_MenuMeta):
     def stop(self):
         """Stops the internal loop."""
         self._running = False
-        if self.__task is not None:
-            self.__task.cancel()
-            self.__task = None
+        if self.__tasks:
+            for task in self.__tasks:
+                task.cancel()
+            self.__tasks.clear()
 
 class PageSource:
     """An interface representing a menu page's data source for the actual menu page.
@@ -882,7 +887,14 @@ class PageSpecifier:
         self.reference = reference
 
     def __repr__(self):
-        return 'PageSpecifier({0.direction!r}, {0.reference!r})'.format(self)
+        return '{0.__class__.__qualname__}({0.direction!r}, {0.reference!r})'.format(self)
+
+    def __eq__(self, other):
+        return (
+            isinstance(other, type(self))
+            and self.direction is other.direction
+            and self.reference == other.reference
+        )
 
     @classmethod
     def first(cls):

--- a/discord/ext/menus/__init__.py
+++ b/discord/ext/menus/__init__.py
@@ -872,7 +872,8 @@ class PageSpecifier:
     direction: :class:`PageDirection`:
         Whether to request the page before or after the last page.
     reference: Any:
-        The next page should be requested relative to this object.
+        The next page should be requested relative to this object, which was returned
+        by :meth:`KeysetPageSource.get_page`.
         None indicates either the first or the last page.
     """
 
@@ -1130,7 +1131,8 @@ class MenuKeysetPages(Menu):
     Attributes
     ------------
     current_page: PageSpecifier
-        The last page that we saw.
+        The last page that we saw. Its :attr:`PageSpecifier.reference` attribute
+        is set to the last object returned by :meth:`PageSpecifier.get_page`.
     """
     def __init__(self, source, **kwargs):
         self._source = source


### PR DESCRIPTION
This PR enables paginating sources which do not support absolute page numbers. For some systems, especially database systems, absolute offset-based page numbers suffer performance and concurrency issues. The typical pagination approach for such systems is to pass the last item seen, and request one page worth of items occurring after that item (a similar approach is taken for getting the previous page). This is called *keyset pagination*.

The existing PageSource API cannot accommodate this without a lot of work. (I tried it, and it would probably require a custom int subclass that supports subtraction from infinity.)

To accomplish keyset pagination, two new classes, `KeysetPageSource`, analogous to `PageSource`, and `MenuKeysetPages`, which is analogous to `MenuPages` are implemented. Consumers should implement a subclass of KeysetPageSource and pass an instance of it to MenuKeysetPages.

To me, the most obvious way of specifying any arbitrary page in a keyset system is with a direction and an optional reference. Direction being before or after, and reference being the last page seen (None indicates the first or last page). A PageDirection enum and PageSpecifier class are added for this purpose. PageSpecifier composes PageDirection, and an instance of it is passed to KeysetPageSource.get_page.