### PR TITLE
Add clear_reaction attribut to Menu class

### DIFF
--- a/discord/ext/menus/__init__.py
+++ b/discord/ext/menus/__init__.py
@@ -323,7 +323,7 @@ class Menu(metaclass=_MenuMeta):
 
         self.timeout = timeout
         self.delete_message_after = delete_message_after
-        self.clear_reaction = clear_reacion
+        self.clear_reaction = clear_reaction
         self.clear_reactions_after = clear_reactions_after
         self.check_embeds = check_embeds
         self._can_remove_reactions = False

--- a/discord/ext/menus/__init__.py
+++ b/discord/ext/menus/__init__.py
@@ -297,6 +297,8 @@ class Menu(metaclass=_MenuMeta):
         The timeout to wait between button inputs.
     delete_message_after: :class:`bool`
         Whether to delete the message after the menu interaction is done.
+    clear_reaction: :class:`bool`
+        Whether to remove the reaction that triggered the event.
     clear_reactions_after: :class:`bool`
         Whether to clear reactions after the menu interaction is done.
         Note that :attr:`delete_message_after` takes priority over this attribute.
@@ -316,11 +318,12 @@ class Menu(metaclass=_MenuMeta):
         calling :meth:`send_initial_message`\, if for example you have a pre-existing
         message you want to attach a menu to.
     """
-    def __init__(self, *, timeout=180.0, delete_message_after=False,
+    def __init__(self, *, timeout=180.0, delete_message_after=False, clear_reaction=True, 
                           clear_reactions_after=False, check_embeds=False, message=None):
 
         self.timeout = timeout
         self.delete_message_after = delete_message_after
+        self.clear_reaction = clear_reacion
         self.clear_reactions_after = clear_reactions_after
         self.check_embeds = check_embeds
         self._can_remove_reactions = False
@@ -636,8 +639,10 @@ class Menu(metaclass=_MenuMeta):
                 async with self._lock:
                     if self._running:
                         await button(self, payload)
+                        await self.message.remove_reaction(payload.emoji, self.bot.get_user(payload.user_id))
             else:
                 await button(self, payload)
+                await self.message.remove_reaction(payload.emoji, self.bot.get_user(payload.user_id))
         except Exception:
             # TODO: logging?
             import traceback


### PR DESCRIPTION
I think it would be cool to add an option to remove the reaction (from the user who reacted to the message) when the event is triggered. I've seen this implemented in some bots already.

I'm not sure what would be the best naming option for this. What are your thoughts on this?