### PR TITLE
Allow ctx.guild and channel.guild to be different guilds

### DIFF
--- a/discord/ext/menus/__init__.py
+++ b/discord/ext/menus/__init__.py
@@ -697,7 +697,7 @@ class Menu(metaclass=_MenuMeta):
         self._author_id = ctx.author.id
         channel = channel or ctx.channel
         is_guild = isinstance(channel, discord.abc.GuildChannel)
-        me = ctx.guild.me if is_guild else ctx.bot.user
+        me = channel.guild.me if is_guild else ctx.bot.user
         permissions = channel.permissions_for(me)
         self.__me = discord.Object(id=me.id)
         self._verify_permissions(ctx, channel, permissions)


### PR DESCRIPTION
Fixes an issue where attempting to start a menu in a channel that's in a different guild than ctx.guild will result in CannotSendMessages.