### PR TITLE
Add auto_remove_reactions option to Menu

### DIFF
--- a/discord/ext/menus/__init__.py
+++ b/discord/ext/menus/__init__.py
@@ -567,7 +567,10 @@ class Menu(metaclass=_MenuMeta):
                     payload = await self.bot.wait_for(
                         'raw_reaction_add', check=self.reaction_check, timeout=self.timeout
                     )
-                    await self.message.remove_reaction(payload.emoji, discord.Object(payload.user_id))
+                    try:
+                        await self.message.remove_reaction(payload.emoji, discord.Object(payload.user_id))
+                    except discord.Forbidden:
+                        pass
                     loop.create_task(self.update(payload))
                 else:
                     tasks = [


### PR DESCRIPTION
Essentially, this allows the `Menu` to function the way 99% of other paginators work, where the user reaction to one of the buttons, and the bot automatically removes it, instead of listening for both the `add` and `remove` events.

It's simply another option, that when enabled, means the bot will only listen to the `add` event and will try to remove the reaction. I intentionally passed the `discord.Forbidden` error and didn't add to the menu permission checks, because if the bot doesn't have permission to remove reactions I want it to keep working and not demand those perms.

Also, thanks so much for making this -- it makes working with reaction menus way more than a "little" easier :)