### PR TITLE
Show page before starting the menu

### DIFF
--- a/discord/ext/menus/__init__.py
+++ b/discord/ext/menus/__init__.py
@@ -964,6 +964,8 @@ class MenuPages(Menu):
 
     async def start(self, ctx, *, channel=None, wait=False):
         await self._source._prepare_once()
+        if self.message is not None:    
+            await self.show_page(0)
         await super().start(ctx, channel=channel, wait=wait)
 
     async def show_checked_page(self, page_number):

--- a/discord/ext/menus/__init__.py
+++ b/discord/ext/menus/__init__.py
@@ -965,7 +965,7 @@ class MenuPages(Menu):
     async def start(self, ctx, *, channel=None, wait=False):
         await self._source._prepare_once()
         if self.message is not None:    
-            await self.show_page(0)
+            await self.show_current_page()
         await super().start(ctx, channel=channel, wait=wait)
 
     async def show_checked_page(self, page_number):


### PR DESCRIPTION
This PR makes it so that `MenuPages` shows the first page on [`MenuPages.start`](https://github.com/Rapptz/discord-ext-menus/blob/master/discord/ext/menus/__init__.py#L965-L967) if a message is supplied.
## Relevant Issues
Fixes #16.

## Solution
In `MenuPages.start`, if `MenuPages.message` is not `None`, it will call `MenuPages.show_page(0)` in order to show the first page when the menu first starts.