### PR TITLE
Update max snowflake length to be 20 characters

### DIFF
--- a/discord/ext/menus/__init__.py
+++ b/discord/ext/menus/__init__.py
@@ -103,7 +103,7 @@ class First(Position):
     def __init__(self, number=0):
         super().__init__(number, bucket=0)
 
-_custom_emoji = re.compile(r'<?(?P<animated>a)?:?(?P<name>[A-Za-z0-9\_]+):(?P<id>[0-9]{13,21})>?')
+_custom_emoji = re.compile(r'<?(?P<animated>a)?:?(?P<name>[A-Za-z0-9\_]+):(?P<id>[0-9]{13,20})>?')
 
 def _cast_emoji(obj, *, _custom_emoji=_custom_emoji):
     if isinstance(obj, discord.PartialEmoji):


### PR DESCRIPTION
While I was going through d.py's commits, I've noticed [a commit](https://github.com/Rapptz/discord.py/commit/a3f700c11f72202f6a7710ce07c7144a8b8c947d) updating the length of snowflakes in regex to be 20 instead of 21 so I assume the update of this would be welcome here too to remain consistent in the code base.